### PR TITLE
fix JSONRPC parse error when getting 'setid' for a movie

### DIFF
--- a/resources/lib/local_db.py
+++ b/resources/lib/local_db.py
@@ -411,7 +411,7 @@ def compare_album_with_library(online_list):
 
 def get_set_name_from_db(dbid):
     json_response = get_kodi_json(method="VideoLibrary.GetMovieDetails",
-                                  params='{"properties": ["setid"], "movieid":%s }"' % dbid)
+                                  params='{"properties": ["setid"], "movieid":%s }' % dbid)
     if "result" in json_response and "moviedetails" in json_response["result"]:
         set_dbid = json_response['result']['moviedetails'].get('setid', "")
         if set_dbid:


### PR DESCRIPTION
Commit d12787a added an additional quotation mark, leading to pase errors and empty movie set lists.