### PR TITLE
Modify Millify Function to remove .000 in Hudreds numbers

### DIFF
--- a/resources/lib/Utils.py
+++ b/resources/lib/Utils.py
@@ -367,7 +367,7 @@ def millify(n):
     """
     make large numbers human-readable, return string
     """
-    millnames = [' ', '.000', ' ' + LANG(32000), ' ' + LANG(32001), ' ' + LANG(32002)]
+    millnames = [' ', '', ' ' + LANG(32000), ' ' + LANG(32001), ' ' + LANG(32002)]
     if not n or n <= 100:
         return ""
     n = float(n)


### PR DESCRIPTION
When returning a value < 1000, the Millify command would append three
trailing zeros after the decimal place.  This makes youtube view counts
Look weird.  Replacing .000 with '' appears to fix the issue.

I tested this with the Youtube search feature and it is returning all values as expected.

Also, the youtube documentation should be updated - there are several missing infolabels that are quite handy.  ;)
