### PR TITLE
fix duration is none error with Trakt

### DIFF
--- a/resources/lib/Trakt.py
+++ b/resources/lib/Trakt.py
@@ -88,8 +88,10 @@ def handle_movies(results):
         trailer = "%syoutubevideo&&id=%s" % (PLUGIN_BASE, utils.extract_youtube_id(item["trailer"]))
         movie = VideoItem(label=item["title"],
                           path=PLUGIN_BASE + path % item["ids"]["tmdb"])
+        if not item["runtime"] is None:
+            duration = item["runtime"] * 60
         movie.set_infos({'title': item["title"],
-                         'duration': item["runtime"] * 60,
+                         'duration': duration,
                          'tagline': item["tagline"],
                          'mediatype': "movie",
                          'trailer': trailer,


### PR DESCRIPTION
I've seen a couple times that the Trakt API returns ```None``` for duration. This leads to an error 
```'duration': item["runtime"] * 60```
```TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'```
