### PR TITLE
Fix fail to start TheMovieDB search

### DIFF
--- a/resources/lib/process.py
+++ b/resources/lib/process.py
@@ -323,6 +323,7 @@ def start_info_actions(info, params):
             if result and result > -1:
                 search_str = result
             else:
+                addon.clear_global('infodialogs.active')
                 return None
         wm.open_video_list(search_str=search_str,
                            mode="search")


### PR DESCRIPTION
If exit virtual keyboard input without a result, need to clear the infodialogs.active flag, or can't enter the search again.