### PR TITLE
Incorrect dict key name

### DIFF
--- a/resources/lib/dialogs/DialogTVShowInfo.py
+++ b/resources/lib/dialogs/DialogTVShowInfo.py
@@ -122,7 +122,7 @@ class DialogTVShowInfo(DialogVideoInfo):
 
     def get_manage_options(self):
         options = []
-        title = self.info.get_info("tvshowtitle")
+        title = self.info.get_info("title")
         dbid = self.info.get_info("dbid")
         if dbid:
             call = "RunScript(script.artwork.downloader,mediatype=tv,dbid={}%s)".format(dbid)


### PR DESCRIPTION
The variable "title" in line 125 does not contain a value using key name "tvshowtitle".  The key name "title" does return the TV show name.  There does not appear to be a key name "tvshowtitle" in function "extended_tvshow_info" in TheMovieDB.py module, where I believe this info is being drawn from.