### PR TITLE
Changed trakt-api-version from int to str

### DIFF
--- a/resources/lib/Trakt.py
+++ b/resources/lib/Trakt.py
@@ -18,7 +18,7 @@ BASE_URL = "https://api-v2launch.trakt.tv/"
 HEADERS = {
     'Content-Type': 'application/json',
     'trakt-api-key': TRAKT_KEY,
-    'trakt-api-version': 2
+    'trakt-api-version': '2'
 }
 PLUGIN_BASE = "plugin://script.extendedinfo/?info="
 


### PR DESCRIPTION
Currently all trakt-section are not working.
Changing the trakt-api-version from an integer to a string fixes this.